### PR TITLE
Fix tooltip overflow issues in popup

### DIFF
--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -32,12 +32,12 @@
                     <div class="flex items-center justify-between">
                         <div class="flex items-center gap-2">
                             <h2 class="text-sm font-medium text-white">Titles</h2>
-                            <div class="relative group">
+                            <div class="relative group tooltip">
                                 <svg class="w-4 h-4 text-gray-400 cursor-help hover:text-gray-300" viewBox="0 0 24 24" fill="currentColor">
                                     <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"/>
                                 </svg>
                                 <span class="absolute z-20 bottom-full left-0 ml-[-20px] mb-2 w-[220px] px-3 py-2 text-xs text-white bg-gray-900/95 rounded-md shadow-lg whitespace-normal opacity-0 pointer-events-none invisible group-hover:opacity-100 group-hover:visible transition-opacity">
-                                    Display original titles : Main video title, Channel Title, recommended videos, search results, etc..
+                                    Display original titles: Main video title, channel title, recommended videos, search results, etc...
                                 </span>
                             </div>
                         </div>
@@ -52,7 +52,7 @@
                     <div class="flex items-center justify-between">
                         <div class="flex items-center gap-2">
                             <h2 class="text-sm font-medium text-white">Audio Tracks</h2>
-                            <div class="relative group">
+                            <div class="relative group tooltip">
                                 <svg class="w-4 h-4 text-gray-400 cursor-help group hover:text-gray-300" viewBox="0 0 24 24" fill="currentColor">
                                     <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"/>
                                 </svg>
@@ -95,11 +95,11 @@
                     <div class="flex items-center justify-between">
                         <div class="flex items-center gap-2">
                             <h2 class="text-sm font-medium text-white">Descriptions</h2>
-                            <div class="relative group">
+                            <div class="relative group tooltip">
                                 <svg class="w-4 h-4 text-gray-400 cursor-help group hover:text-gray-300" viewBox="0 0 24 24" fill="currentColor">
                                     <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"/>
                                 </svg>
-                                <span class="absolute z-20 bottom-full left-0 ml-[-20px] mb-2 w-[220px] px-3 py-2 text-xs text-white bg-gray-900/95 rounded-md shadow-lg whitespace-normal opacity-0 pointer-events-none invisible group-hover:opacity-100 group-hover:visible transition-opacity">    
+                                <span class="absolute z-20 bottom-full left-0 ml-[-20px] mb-2 w-[220px] px-3 py-2 text-xs text-white bg-gray-900/95 rounded-md shadow-lg whitespace-normal opacity-0 pointer-events-none invisible group-hover:opacity-100 group-hover:visible transition-opacity">
                                     If description is translated, it will be replaced with the original description.
                                 </span>
                             </div>
@@ -115,7 +115,7 @@
                     <div class="flex items-center justify-between">
                         <div class="flex items-center gap-2">
                             <h2 class="text-sm font-medium text-white">Subtitles</h2>
-                            <div class="relative group">
+                            <div class="relative group tooltip">
                                 <svg class="w-4 h-4 text-gray-400 cursor-help group hover:text-gray-300" viewBox="0 0 24 24" fill="currentColor">
                                     <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"/>
                                 </svg>

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -13,6 +13,7 @@ const audioLanguageSelect = document.getElementById('audioLanguage') as HTMLSele
 const descriptionToggle = document.getElementById('descriptionTranslation') as HTMLInputElement;
 const subtitlesToggle = document.getElementById('subtitlesTranslation') as HTMLInputElement;
 const subtitlesLanguageSelect = document.getElementById('subtitlesLanguage') as HTMLSelectElement;
+const tooltipGroups = document.querySelectorAll('.tooltip') as NodeListOf<HTMLDivElement>;
 
 // Initialize toggle states from storage
 document.addEventListener('DOMContentLoaded', async () => {
@@ -274,5 +275,16 @@ audioLanguageSelect.addEventListener('change', async () => {
         }
     } catch (error) {
         console.error('Failed to save audio language:', error);
+    }
+});
+
+// Adjust tooltip positions if they overflow the viewport
+tooltipGroups.forEach((group) => {
+    const bodyWidth = document.body.clientWidth;  
+    const tooltip = group.querySelector('span') as HTMLSpanElement;
+    const tooltipRect = tooltip.getBoundingClientRect();
+
+    if (tooltipRect.right > bodyWidth) {
+        tooltip.style.marginLeft = `-${tooltipRect.right - bodyWidth + 20}px`;
     }
 });


### PR DESCRIPTION
I saw that the tooltip for the audio tracks and descriptions overflows on the right side of the extension settings menu. This creates the horizontal scroolbar and without scrolling not the whole text is visible. I created a TypeScript solution that changes the left margin if the right side of the tooltip is bigger than the right side of the document body.

Also unified the capitalization of the tooltip text on one occasion.

Good work on the plugin which I use on all my devices! Wanted to help out with this small PR.