### PR TITLE
Feat/batch yt data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Refactored
+- process individual title fetches in parallel instead of sequential for refreshBrowsingVideos
+- If YouTube Data API feature is enabled, a batch request is made for titles & search descriptions for less network traffic and resquests consumption
+
 ## [2.9.0] - 2025-07-14
 
 ### Feat

--- a/docs/YT_DATA_API.md
+++ b/docs/YT_DATA_API.md
@@ -4,8 +4,7 @@
 
 With this API, you can:
 - Retrieve original channel name & description on (@) channel page.
-- Use it as a reliable fallback for titles & descriptions
-- Coming soon : Get all original titles & descriptions in the page in one api request.
+- Get all original titles & descriptions on the page in one api request. (making updates way faster in theory)
 
 **Note: Using the YouTube Data API requires you to obtain your own API key.**
 
@@ -15,7 +14,7 @@ Go to the official Google documentation:
 https://developers.google.com/youtube/v3/getting-started  
 Everything is explained step by step to create a project and generate an API key.
 
-**Note: By default, the API has a limit of 10,000 units (requests) per day (the extension only use methods that need 1 unit/request), which is more than enough for most users. But, just in case, the extension only uses it as a fallback for titles, to avoid reaching the quota too quickly.**
+**Note: By default, the API has a limit of 10,000 units (requests) per day (the extension only use methods that need 1 unit/request), which is more than enough for most users. Especially now that we only make 1 request for 50 different videos.**
 
 ## How to use the key in the extension
 

--- a/src/content/description/searchDescriptions.ts
+++ b/src/content/description/searchDescriptions.ts
@@ -207,9 +207,99 @@ export function shouldProcessSearchDescriptionElement(isTranslated: boolean): bo
         currentSettings.descriptionTranslation
 }
 
-export async function processSearchDescriptionElement(titleElement: HTMLElement, videoId: string): Promise<void> {
-    try {
-        // Find the video element container to get description
+// New function to batch fetch descriptions from YouTube Data API v3
+async function batchFetchDescriptionsFromYouTubeDataApi(videoIds: string[]): Promise<Map<string, string>> {
+    const descriptionMap = new Map<string, string>();
+    
+    if (!currentSettings?.youtubeDataApi?.enabled || !currentSettings?.youtubeDataApi?.apiKey) {
+        return descriptionMap;
+    }
+
+    // Process in batches of 50 (YouTube Data API v3 limit)
+    const batchSize = 50;
+    for (let i = 0; i < videoIds.length; i += batchSize) {
+        const batch = videoIds.slice(i, i + batchSize);
+        const idsParam = batch.join(',');
+        
+        try {
+            const youtubeApiUrl = `https://www.googleapis.com/youtube/v3/videos?id=${idsParam}&key=${currentSettings.youtubeDataApi.apiKey}&part=snippet`;
+            const response = await fetch(youtubeApiUrl);
+            
+            if (response.ok) {
+                const data = await response.json();
+                if (data.items) {
+                    data.items.forEach((item: any) => {
+                        if (item.snippet?.description) {
+                            descriptionMap.set(item.id, item.snippet.description);
+                        }
+                    });
+                }
+            } else {
+                descriptionErrorLog(`YouTube Data API v3 batch failed for descriptions: ${response.status} ${response.statusText}`);
+            }
+        } catch (apiError) {
+            descriptionErrorLog(`YouTube Data API v3 batch error for descriptions:`, apiError);
+        }
+    }
+    
+    return descriptionMap;
+}
+
+// Modified function to accept pre-fetched descriptions
+async function fetchOriginalDescription(
+    videoId: string,
+    preferenceFetchedDescriptions?: Map<string, string>
+): Promise<string | null> {
+    let originalDescription: string | null = null;
+    
+    // Check pre-fetched descriptions first (from YouTube Data API v3 batch)
+    if (preferenceFetchedDescriptions?.has(videoId)) {
+        const batchDescription = preferenceFetchedDescriptions.get(videoId);
+        if (batchDescription && batchDescription.trim()) {
+            originalDescription = batchDescription;
+        }
+    }
+    
+    // Try InnerTube API if not found in pre-fetched
+    if (!originalDescription) {
+        try {
+            originalDescription = await fetchSearchDescriptionInnerTube(videoId);
+        } catch (error) {
+            descriptionErrorLog(`InnerTube API error for description ${videoId}:`, error);
+        }
+    }
+    
+    // Individual YouTube Data API v3 call as fallback (only if batching wasn't used)
+    if (!originalDescription && !preferenceFetchedDescriptions && currentSettings?.youtubeDataApi?.enabled && currentSettings?.youtubeDataApi?.apiKey) {
+        try {
+            originalDescription = await fetchSearchDescriptionDataApi(videoId);
+        } catch (error) {
+            descriptionErrorLog(`YouTube Data API v3 individual error for description ${videoId}:`, error);
+        }
+    }
+    
+    return originalDescription;
+}
+
+// New function to collect and batch process descriptions
+export async function batchProcessSearchDescriptions(titleElements: HTMLElement[], videoIds: string[]): Promise<void> {
+    if (!currentSettings?.descriptionTranslation || !isSearchResultsPage()) {
+        return;
+    }
+
+    // Collect video elements that need description processing
+    const descriptionsToProcess: Array<{ 
+        descriptionElement: HTMLElement; 
+        videoId: string; 
+        titleElement: HTMLElement;
+    }> = [];
+
+    for (let i = 0; i < titleElements.length; i++) {
+        const titleElement = titleElements[i];
+        const videoId = videoIds[i];
+        
+        if (!titleElement || !videoId) continue;
+
         const videoElement = titleElement.closest('ytd-video-renderer') as HTMLElement;
         if (videoElement) {
             let descriptionElement = videoElement.querySelector('.metadata-snippet-text') as HTMLElement | null;
@@ -217,6 +307,7 @@ export async function processSearchDescriptionElement(titleElement: HTMLElement,
                 // Fallback for history page
                 descriptionElement = videoElement.querySelector('#description-text') as HTMLElement | null;
             }
+            
             if (descriptionElement) {
                 // Check if description already processed
                 const isAlreadyProcessed = descriptionElement.hasAttribute('ynt-search') && 
@@ -225,30 +316,43 @@ export async function processSearchDescriptionElement(titleElement: HTMLElement,
                                   descriptionElement.getAttribute('ynt-search-fail') === videoId;
                 
                 if (!isAlreadyProcessed && !hasFailed) {
-                    try {
-                        let originalDescription: string | null = null;
-                        
-                        // Fetch description using InnerTube API first
-                        originalDescription = await fetchSearchDescriptionInnerTube(videoId);
-
-                        // Try YouTube Data API v3 first if enabled and API key available
-                        if (currentSettings?.youtubeDataApi?.enabled && currentSettings?.youtubeDataApi?.apiKey) {
-                            originalDescription = await fetchSearchDescriptionDataApi(videoId);
-                        }
-                        
-                        if (originalDescription) {
-                            updateSearchDescriptionElement(descriptionElement, originalDescription, videoId);
-                        } else {
-                            descriptionElement.setAttribute('ynt-search-fail', videoId);
-                        }
-                    } catch (descError) {
-                        descriptionErrorLog(`Failed to update search description for ${videoId}:`, descError);
-                        descriptionElement.setAttribute('ynt-search-fail', videoId);
-                    }
+                    descriptionsToProcess.push({ descriptionElement, videoId, titleElement });
                 }
             }
         }
-    } catch (error) {
-        descriptionErrorLog(`Failed to process description for ${videoId}:`, error);
     }
+
+    if (descriptionsToProcess.length === 0) {
+        return;
+    }
+
+    // Batch fetch descriptions from YouTube Data API v3 if enabled
+    let preferenceFetchedDescriptions: Map<string, string> | undefined;
+    if (currentSettings?.youtubeDataApi?.enabled && currentSettings?.youtubeDataApi?.apiKey) {
+        const descriptionVideoIds = descriptionsToProcess.map(d => d.videoId);
+        preferenceFetchedDescriptions = await batchFetchDescriptionsFromYouTubeDataApi(descriptionVideoIds);
+        descriptionLog(`Batch fetched ${preferenceFetchedDescriptions.size} descriptions from YouTube Data API v3`);
+    }
+
+    // Process each description
+    for (const { descriptionElement, videoId, titleElement } of descriptionsToProcess) {
+        try {
+            const originalDescription = await fetchOriginalDescription(videoId, preferenceFetchedDescriptions);
+            
+            if (originalDescription) {
+                updateSearchDescriptionElement(descriptionElement, originalDescription, videoId);
+            } else {
+                descriptionElement.setAttribute('ynt-search-fail', videoId);
+            }
+        } catch (descError) {
+            descriptionErrorLog(`Failed to update search description for ${videoId}:`, descError);
+            descriptionElement.setAttribute('ynt-search-fail', videoId);
+        }
+    }
+}
+
+// Keep the original function for backward compatibility but simplify it
+export async function processSearchDescriptionElement(titleElement: HTMLElement, videoId: string): Promise<void> {
+    // For individual processing, use the new batch function with single elements
+    await batchProcessSearchDescriptions([titleElement], [videoId]);
 }

--- a/src/content/observers.ts
+++ b/src/content/observers.ts
@@ -27,6 +27,7 @@ import { cleanupAllSearchDescriptionsObservers } from './description/searchDescr
 import { refreshEndScreenTitles, setupEndScreenObserver, cleanupEndScreenObserver } from './titles/endScreenTitles';
 import { refreshChannelShortDescription, cleanupChannelDescriptionModalObserver } from './description/channelDescription';
 import { refreshMainChannelName } from './channelName/mainChannelName';
+import { isYouTubeDataAPIEnabled } from '../utils/utils';
 
 
 // MAIN OBSERVERS -----------------------------------------------------------
@@ -856,7 +857,7 @@ function handleUrlChange() {
         coreLog(`[URL] Detected channel page`);
         if (currentSettings?.titleTranslation) {
             pageVideosObserver();
-            if (currentSettings?.youtubeDataApi.enabled && currentSettings?.youtubeDataApi.apiKey) {
+            if (isYouTubeDataAPIEnabled(currentSettings)) {
                 // Wait for the channel name element to be present before calling refreshMainChannelName
                 waitForElement('yt-dynamic-text-view-model h1.dynamic-text-view-model-wiz__h1 > span.yt-core-attributed-string')
                     .then(() => {
@@ -867,7 +868,7 @@ function handleUrlChange() {
                     });
             }
         }
-        if (currentSettings?.descriptionTranslation && currentSettings?.youtubeDataApi.enabled && currentSettings?.youtubeDataApi.apiKey) {
+        if (currentSettings?.descriptionTranslation && isYouTubeDataAPIEnabled(currentSettings)) {
             // Refresh channel short description
             waitForElement('yt-description-preview-view-model').then(() => {
                 refreshChannelShortDescription();

--- a/src/content/titles/browsingTitles.ts
+++ b/src/content/titles/browsingTitles.ts
@@ -221,10 +221,59 @@ function checkElementProcessingState(titleElement: HTMLElement, videoId: string)
 }
 
 
-export async function fetchOriginalTitle(videoId: string, titleElement: HTMLElement, currentTitle: string): Promise<TitleFetchResult> {
-    // Try oEmbed API first
-    let originalTitle: string | null = null;   
+// New function to batch fetch titles from YouTube Data API v3
+async function batchFetchTitlesFromYouTubeDataApi(videoIds: string[]): Promise<Map<string, string>> {
+    const titleMap = new Map<string, string>();
     
+    if (!currentSettings?.youtubeDataApi?.enabled || !currentSettings?.youtubeDataApi?.apiKey) {
+        return titleMap;
+    }
+
+    // Process in batches of 50 (YouTube Data API v3 limit)
+    const batchSize = 50;
+    for (let i = 0; i < videoIds.length; i += batchSize) {
+        const batch = videoIds.slice(i, i + batchSize);
+        const idsParam = batch.join(',');
+        
+        try {
+            const youtubeApiUrl = `https://www.googleapis.com/youtube/v3/videos?id=${idsParam}&key=${currentSettings.youtubeDataApi.apiKey}&part=snippet`;
+            const response = await fetch(youtubeApiUrl);
+            
+            if (response.ok) {
+                const data = await response.json();
+                if (data.items) {
+                    data.items.forEach((item: any) => {
+                        if (item.snippet?.title) {
+                            titleMap.set(item.id, item.snippet.title);
+                        }
+                    });
+                }
+            } else {
+                browsingTitlesErrorLog(`YouTube Data API v3 batch failed: ${response.status} ${response.statusText}`);
+            }
+        } catch (apiError) {
+            browsingTitlesErrorLog(`YouTube Data API v3 batch error:`, apiError);
+        }
+    }
+    
+    return titleMap;
+}
+
+// Modified function with new signature to accept pre-fetched titles
+export async function fetchOriginalTitle(
+    videoId: string, 
+    titleElement: HTMLElement, 
+    currentTitle: string,
+    preferenceFetchedTitles?: Map<string, string>
+): Promise<TitleFetchResult> {
+    let originalTitle: string | null = null;
+    
+    // Check pre-fetched titles first (from YouTube Data API v3 batch)
+    if (preferenceFetchedTitles?.has(videoId)) {
+        originalTitle = preferenceFetchedTitles.get(videoId) || null;
+    }
+    
+    // Try oEmbed API if not found in pre-fetched
     if (!originalTitle) {
         try {
             const apiUrl = `https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=${videoId}`;
@@ -236,30 +285,10 @@ export async function fetchOriginalTitle(videoId: string, titleElement: HTMLElem
     
     // Try InnerTube API if oEmbed fails
     if (!originalTitle) {
-        //browsingTitlesLog(`Oembed api failed, fetching title from InnerTube API for ${videoId}`);
         try {
             originalTitle = await fetchTitleInnerTube(videoId) ?? '';
         } catch (error) {
             browsingTitlesErrorLog(`InnerTube API error for ${videoId}:`, error);
-        }
-    }
-
-    // If oEmbed & InnerTube fails, try YouTube Data API v3 if enabled and API key available
-    if (!originalTitle && currentSettings?.youtubeDataApi?.enabled && currentSettings?.youtubeDataApi?.apiKey) {
-        try {
-            const youtubeApiUrl = `https://www.googleapis.com/youtube/v3/videos?id=${videoId}&key=${currentSettings.youtubeDataApi.apiKey}&part=snippet`;
-            const response = await fetch(youtubeApiUrl);
-            
-            if (response.ok) {
-                const data = await response.json();
-                if (data.items && data.items.length > 0) {
-                    originalTitle = data.items[0].snippet.title;
-                }
-            } else {
-                browsingTitlesErrorLog(`YouTube Data API v3 failed for ${videoId}: ${response.status} ${response.statusText}`);
-            }
-        } catch (apiError) {
-            browsingTitlesErrorLog(`YouTube Data API v3 error for ${videoId}:`, apiError);
         }
     }
     
@@ -315,7 +344,6 @@ export async function fetchOriginalTitle(videoId: string, titleElement: HTMLElem
     return { originalTitle, shouldSkip: false, shouldMarkAsOriginal: false, shouldMarkAsFailed: false };
 }
 
-
 export async function refreshBrowsingVideos(): Promise<void> {
     const now = Date.now();
     if (now - lastBrowsingTitlesRefresh < TITLES_THROTTLE) {
@@ -334,41 +362,60 @@ export async function refreshBrowsingVideos(): Promise<void> {
     // Merge both lists
     const browsingTitles = [...classicTitles, ...recommendedTitles];
 
+    // Collect all video IDs that need processing
+    const videosToProcess: Array<{ titleElement: HTMLElement; videoId: string; videoUrl: string; currentTitle: string }> = [];
+    
     for (const titleElement of browsingTitles) {
-        //browsingTitlesLog('Processing video title:', titleElement.textContent);
-        
         const processingResult = shouldProcessBrowsingElement(titleElement);
         if (!processingResult.shouldProcess || !processingResult.videoId) {
             continue;
         }
         
         const { videoId, videoUrl } = processingResult;
+        
+        // Skip if this video is currently being processed
+        if (processingVideos.has(videoId)) {
+            continue;
+        }
+        
+        const currentTitle = titleElement.textContent || '';
+        
+        const processingState = checkElementProcessingState(titleElement, videoId);
+        if (processingState.shouldSkip) {
+            continue;
+        }
+        if (processingState.shouldClean) {
+            titleElement.removeAttribute('ynt');
+            titleElement.removeAttribute('ynt-fail');
+            titleElement.removeAttribute('ynt-fail-retry');
+            titleElement.removeAttribute('ynt-original');
+        }
+        
+        videosToProcess.push({ titleElement, videoId, videoUrl: videoUrl as string, currentTitle });
+    }
+
+    // Batch fetch titles from YouTube Data API v3 if enabled
+    let preferenceFetchedTitles: Map<string, string> | undefined;
+    if (currentSettings?.youtubeDataApi?.enabled && currentSettings?.youtubeDataApi?.apiKey && videosToProcess.length > 0) {
+        const videoIds = videosToProcess.map(v => v.videoId);
+        preferenceFetchedTitles = await batchFetchTitlesFromYouTubeDataApi(videoIds);
+        browsingTitlesLog(`Batch fetched ${preferenceFetchedTitles.size} titles from YouTube Data API v3`);
+    }
+
+    // Process each video
+    for (const { titleElement, videoId, videoUrl, currentTitle } of videosToProcess) {
         let isTranslated = false;
         
         // Mark this video as being processed
         processingVideos.add(videoId);
         try {
-            const currentTitle = titleElement.textContent || '';
-
-            const processingState = checkElementProcessingState(titleElement, videoId);
-            if (processingState.shouldSkip) {
-                continue;
-            }
-            if (processingState.shouldClean) {
-                titleElement.removeAttribute('ynt');
-                titleElement.removeAttribute('ynt-fail');
-                titleElement.removeAttribute('ynt-fail-retry');
-                titleElement.removeAttribute('ynt-original');
-            }
-            
-            const titleFetchResult = await fetchOriginalTitle(videoId, titleElement, currentTitle);
+            const titleFetchResult = await fetchOriginalTitle(videoId, titleElement, currentTitle, preferenceFetchedTitles);
             if (titleFetchResult.shouldSkip) {
                 continue;
             }
 
             const originalTitle = titleFetchResult.originalTitle;
             if (!originalTitle) {
-                //browsingTitlesErrorLog('Failed to get original title :', videoId, currentTitle);
                 continue;
             }
 
@@ -381,7 +428,7 @@ export async function refreshBrowsingVideos(): Promise<void> {
 
             // Process search descriptions if on search page and feature enabled
             if (shouldProcessSearchDescriptionElement(isTranslated)) {
-                await processSearchDescriptionElement(titleElement, videoId);
+                processSearchDescriptionElement(titleElement, videoId);
             }
 
         } finally {

--- a/src/content/titles/browsingTitles.ts
+++ b/src/content/titles/browsingTitles.ts
@@ -12,6 +12,7 @@ import { ProcessingResult, ElementProcessingState, TitleFetchResult } from '../.
 import { currentSettings } from '../index';
 import { normalizeText } from '../../utils/text';
 import { extractVideoIdFromUrl } from '../../utils/video';
+import { isYouTubeDataAPIEnabled } from '../../utils/utils';
 import { shouldProcessSearchDescriptionElement, batchProcessSearchDescriptions } from '../description/searchDescriptions';
 import { titleCache, fetchTitleInnerTube } from './index';
 
@@ -224,8 +225,8 @@ function checkElementProcessingState(titleElement: HTMLElement, videoId: string)
 // New function to batch fetch titles from YouTube Data API v3
 async function batchFetchTitlesFromYouTubeDataApi(videoIds: string[]): Promise<Map<string, string>> {
     const titleMap = new Map<string, string>();
-    
-    if (!currentSettings?.youtubeDataApi?.enabled || !currentSettings?.youtubeDataApi?.apiKey) {
+
+    if (!isYouTubeDataAPIEnabled(currentSettings)) {
         return titleMap;
     }
 
@@ -236,7 +237,7 @@ async function batchFetchTitlesFromYouTubeDataApi(videoIds: string[]): Promise<M
         const idsParam = batch.join(',');
         
         try {
-            const youtubeApiUrl = `https://www.googleapis.com/youtube/v3/videos?id=${idsParam}&key=${currentSettings.youtubeDataApi.apiKey}&part=snippet`;
+            const youtubeApiUrl = `https://www.googleapis.com/youtube/v3/videos?id=${idsParam}&key=${currentSettings?.youtubeDataApi.apiKey}&part=snippet`;
             const response = await fetch(youtubeApiUrl);
             
             if (response.ok) {
@@ -396,7 +397,7 @@ export async function refreshBrowsingVideos(): Promise<void> {
 
     // Batch fetch titles from YouTube Data API v3 if enabled
     let preferenceFetchedTitles: Map<string, string> | undefined;
-    if (currentSettings?.youtubeDataApi?.enabled && currentSettings?.youtubeDataApi?.apiKey && videosToProcess.length > 0) {
+    if (isYouTubeDataAPIEnabled(currentSettings) && videosToProcess.length > 0) {
         const videoIds = videosToProcess.map(v => v.videoId);
         preferenceFetchedTitles = await batchFetchTitlesFromYouTubeDataApi(videoIds);
         browsingTitlesLog(`Batch fetched ${preferenceFetchedTitles.size} titles from YouTube Data API v3`);

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -102,3 +102,18 @@ export function getChannelName(url: string): string | null {
     }
     return null;
 }
+
+/**
+ * Checks if the YouTube Data API feature is enabled and the API key is valid (length > 10).
+ * @param settings The settings object containing youtubeDataApi config.
+ * @returns True if enabled and apiKey is valid, false otherwise.
+ */
+export function isYouTubeDataAPIEnabled(settings: { youtubeDataApi?: { enabled?: boolean; apiKey?: string } } | null | undefined): boolean {
+    return !!(
+        settings &&
+        settings.youtubeDataApi &&
+        settings.youtubeDataApi.enabled &&
+        typeof settings.youtubeDataApi.apiKey === 'string' &&
+        settings.youtubeDataApi.apiKey.length > 10
+    );
+}


### PR DESCRIPTION
Added batch fetching if yt data api feature is enabled, allowing to fetch all video (up to 50) in one request. Making updating faster and request consumption / 50. (Browsing titles & Search results descriptions