### PR TITLE
feat: InfoCards support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Feat
+- **InfoCards Support**: Original titles are now restored for video annotations (infocards) in video descriptions and their corresponding overlay teasers
+
 ## [2.15.2] - 2025-10-09
 
 ### Fix

--- a/src/content/observers.ts
+++ b/src/content/observers.ts
@@ -31,6 +31,8 @@ import { refreshMainChannelName } from './channel/mainChannelName';
 import { patchChannelRendererBlocks } from './channel/ChannelRendererPatch';
 import { refreshChannelPlayer } from './channel/channelPlayer';
 import { processChannelVideoDescriptions } from './channel/ChannelVideoDescriptions';
+import { refreshInfoCardsTitles, cleanupInfoCards } from './titles/infoCards';
+import { setupInfoCardTeasersObserver, cleanupInfoCardTeasersObserver } from  './titles/infoCardsTeasers';
 
 // MAIN OBSERVERS -----------------------------------------------------------
 let videoPlayerListener: ((e: Event) => void) | null = null;
@@ -661,6 +663,9 @@ function observersCleanup() {
     cleanupPostVideoObserver();
 
     cleanupChannelDescriptionModalObserver();
+
+    cleanupInfoCards();
+    cleanupInfoCardTeasersObserver();
 }
 
 function handleUrlChange() {
@@ -782,10 +787,15 @@ function handleUrlChange() {
             if (currentSettings?.titleTranslation || currentSettings?.descriptionTranslation) {
                 setupMainVideoObserver();
             };
-            currentSettings?.titleTranslation && recommendedVideosObserver();
+
+            if (currentSettings?.titleTranslation) {
+                recommendedVideosObserver();
+                setupEndScreenObserver();
+                setupPostVideoObserver();
+                refreshInfoCardsTitles();
+                setupInfoCardTeasersObserver();
+            }
             currentSettings?.descriptionTranslation && setupTimestampClickObserver();
-            currentSettings?.titleTranslation && setupEndScreenObserver();
-            currentSettings?.titleTranslation && setupPostVideoObserver();
             
             // Handle fullscreen titles (embed titles are specific to /watch pages)
             if (currentSettings?.titleTranslation) {
@@ -820,6 +830,7 @@ export function setupVisibilityChangeListener(): void {
                 if (window.location.pathname === '/watch') {
                     refreshMainTitle();
                     refreshEndScreenTitles();
+                    refreshInfoCardsTitles();
                 }
             }
         }

--- a/src/content/titles/infoCards.ts
+++ b/src/content/titles/infoCards.ts
@@ -1,0 +1,177 @@
+/* 
+ * Copyright (C) 2025-present YouGo (https://github.com/youg-o)
+ * This program is licensed under the GNU Affero General Public License v3.0.
+ * You may redistribute it and/or modify it under the terms of the license.
+ * 
+ * Attribution must be given to the original author.
+ * This program is distributed without any warranty; see the license for details.
+ */
+
+import { titlesLog, titlesErrorLog } from '../../utils/logger';
+import { normalizeText } from '../../utils/text';
+import { extractVideoIdFromUrl } from '../../utils/video';
+import { updateBrowsingTitleElement, fetchOriginalTitle } from './browsingTitles';
+
+// Structure to store infocard data (translated + original titles)
+interface InfoCardData {
+    translatedTitle: string;
+    originalTitle: string;
+}
+
+/**
+ * Manages infocard data (translated and original titles) for overlay teaser matching.
+ */
+class InfoCardDataManager {
+    private dataMap = new Map<string, InfoCardData>();
+
+    /**
+     * Stores infocard data for a video.
+     */
+    set(videoId: string, translatedTitle: string, originalTitle: string): void {
+        this.dataMap.set(videoId, { translatedTitle, originalTitle });
+    }
+
+    /**
+     * Retrieves infocard data by video ID.
+     */
+    get(videoId: string): InfoCardData | undefined {
+        return this.dataMap.get(videoId);
+    }
+
+    /**
+     * Finds infocard data by translated title (normalized comparison).
+     */
+    findByTranslatedTitle(translatedTitle: string): InfoCardData | undefined {
+        const normalizedSearch = normalizeText(translatedTitle);
+        for (const [videoId, data] of this.dataMap.entries()) {
+            if (normalizeText(data.translatedTitle) === normalizedSearch) {
+                return data;
+            }
+        }
+        return undefined;
+    }
+
+    /**
+     * Clears all stored infocard data.
+     */
+    clear(): void {
+        this.dataMap.clear();
+        titlesLog('InfoCard data cleared');
+    }
+
+    /**
+     * Returns the number of stored infocards.
+     */
+    size(): number {
+        return this.dataMap.size;
+    }
+}
+
+// Singleton instance
+export const infoCardDataManager = new InfoCardDataManager();
+
+let infoCardsDebounceTimer: number | null = null;
+const INFOCARDS_DEBOUNCE_MS = 200;
+
+/**
+ * Clears the infocards debounce timer.
+ */
+export function cleanupInfoCardsDebounce(): void {
+    if (infoCardsDebounceTimer !== null) {
+        clearTimeout(infoCardsDebounceTimer);
+        infoCardsDebounceTimer = null;
+    }
+}
+
+/**
+ * Processes all infocards in the description and stores their data.
+ */
+export async function refreshInfoCardsTitles(): Promise<void> {
+    // Clear existing debounce timer
+    if (infoCardsDebounceTimer !== null) {
+        clearTimeout(infoCardsDebounceTimer);
+    }
+
+    // Set new debounce timer
+    infoCardsDebounceTimer = window.setTimeout(async () => {
+        const infoCardTitleElements = Array.from(
+            document.querySelectorAll('ytd-structured-description-video-lockup-renderer #title')
+        ) as HTMLElement[];
+
+        if (infoCardTitleElements.length === 0) {
+            return;
+        }
+
+        titlesLog(`Processing ${infoCardTitleElements.length} infocard titles`);
+
+        // Process each infocard
+        for (const titleElement of infoCardTitleElements) {
+            try {
+                // Find the parent link to get videoId
+                const linkElement = titleElement.closest('a#text-wrapper') as HTMLAnchorElement | null;
+                if (!linkElement) {
+                    continue;
+                }
+
+                const videoUrl = linkElement.href;
+                const videoId = extractVideoIdFromUrl(videoUrl);
+                
+                if (!videoId) {
+                    continue;
+                }
+
+                // Skip if already processed (has ynt attribute)
+                if (titleElement.hasAttribute('ynt') && titleElement.getAttribute('ynt') === videoId) {
+                    continue;
+                }
+
+                // Capture the translated title BEFORE replacing it
+                const translatedTitle = titleElement.textContent?.trim() || '';
+                
+                if (!translatedTitle) {
+                    continue;
+                }
+
+                // Fetch the original title
+                const titleFetchResult = await fetchOriginalTitle(videoId, titleElement, translatedTitle);
+                
+                if (titleFetchResult.shouldSkip || !titleFetchResult.originalTitle) {
+                    continue;
+                }
+
+                const originalTitle = titleFetchResult.originalTitle;
+
+                // Store both translated and original titles
+                infoCardDataManager.set(videoId, translatedTitle, originalTitle);
+
+                // Update the title element with the original title
+                updateBrowsingTitleElement(titleElement, originalTitle, videoId, false);
+
+                titlesLog(
+                    `InfoCard stored: %c${videoId}%c - Translated: %c${normalizeText(translatedTitle)}%c → Original: %c${normalizeText(originalTitle)}%c`,
+                    'color: #4ade80',
+                    'color: #fca5a5',
+                    'color: grey',
+                    'color: #fca5a5',
+                    'color: white',
+                    'color: #fca5a5'
+                );
+
+            } catch (error) {
+                titlesErrorLog('Error processing infocard:', error);
+            }
+        }
+
+        titlesLog(`Stored ${infoCardDataManager.size()} infocard data entries`);
+
+        infoCardsDebounceTimer = null;
+    }, INFOCARDS_DEBOUNCE_MS);
+}
+
+/**
+ * Cleans up all infocard-related data and timers.
+ */
+export function cleanupInfoCards(): void {
+    cleanupInfoCardsDebounce();
+    infoCardDataManager.clear();
+}

--- a/src/content/titles/infoCardsTeasers.ts
+++ b/src/content/titles/infoCardsTeasers.ts
@@ -1,0 +1,250 @@
+/* 
+ * Copyright (C) 2025-present YouGo (https://github.com/youg-o)
+ * This program is licensed under the GNU Affero General Public License v3.0.
+ * You may redistribute it and/or modify it under the terms of the license.
+ * 
+ * Attribution must be given to the original author.
+ * This program is distributed without any warranty; see the license for details.
+ */
+
+import { titlesLog, titlesErrorLog } from '../../utils/logger';
+import { normalizeText } from '../../utils/text';
+import { infoCardDataManager } from './infoCards';
+
+let teaserObserver: MutationObserver | null = null;
+let teaserLabelObservers = new Map<HTMLElement, MutationObserver>();
+let teaserDebounceTimer: number | null = null;
+const TEASER_DEBOUNCE_MS = 100;
+
+/**
+ * Checks if the teaser is currently visible.
+ */
+function isTeaserVisible(teaserElement: HTMLElement): boolean {
+    const style = window.getComputedStyle(teaserElement);
+    return style.display !== 'none' && style.visibility !== 'hidden';
+}
+
+/**
+ * Updates a teaser label with the original title.
+ */
+function updateTeaserLabel(labelElement: HTMLElement): void {
+    const translatedTitle = labelElement.textContent?.trim();
+    
+    if (!translatedTitle) {
+        return;
+    }
+
+    // Find the original title using the translated title
+    const infoCardData = infoCardDataManager.findByTranslatedTitle(translatedTitle);
+    
+    if (!infoCardData) {
+        //titlesLog(`No matching infocard found for teaser: "${translatedTitle}"`);
+        return;
+    }
+
+    const originalTitle = infoCardData.originalTitle;
+
+    // Skip if already showing original title
+    if (normalizeText(translatedTitle) === normalizeText(originalTitle)) {
+        return;
+    }
+
+    // Update the teaser label with the original title
+    labelElement.textContent = originalTitle;
+    labelElement.setAttribute('ynt-teaser', 'true');
+    labelElement.setAttribute('ynt-teaser-translated', translatedTitle); // Store translated title for verification
+
+    titlesLog(
+        `Teaser updated: %c${normalizeText(translatedTitle)}%c → %c${normalizeText(originalTitle)}%c`,
+        'color: grey',
+        'color: #fca5a5',
+        'color: white',
+        'color: #fca5a5'
+    );
+
+    // Setup observer to prevent YouTube from changing it back
+    setupTeaserLabelObserver(labelElement, translatedTitle, originalTitle);
+}
+
+/**
+ * Processes the teaser if it's visible and has a label.
+ */
+function processTeaserIfVisible(): void {
+    const teaserContainer = document.querySelector('.ytp-cards-teaser') as HTMLElement;
+    
+    if (!teaserContainer || !isTeaserVisible(teaserContainer)) {
+        return;
+    }
+
+    const teaserLabel = teaserContainer.querySelector('.ytp-cards-teaser-label') as HTMLElement;
+    
+    if (teaserLabel) {
+        // Clean up all previous observers before processing new teaser
+        cleanupAllTeaserLabelObservers();
+        
+        // Remove the ynt-teaser attribute to allow re-processing
+        teaserLabel.removeAttribute('ynt-teaser');
+        teaserLabel.removeAttribute('ynt-teaser-translated');
+        
+        updateTeaserLabel(teaserLabel);
+    }
+}
+
+/**
+ * Sets up an observer to keep the teaser label showing the original title.
+ */
+function setupTeaserLabelObserver(labelElement: HTMLElement, expectedTranslatedTitle: string, originalTitle: string): void {
+    // Clean up any existing observer for this element
+    cleanupTeaserLabelObserver(labelElement);
+
+    const observer = new MutationObserver((mutations) => {
+        mutations.forEach((mutation) => {
+            if (mutation.type === 'childList' || mutation.type === 'characterData') {
+                const currentText = labelElement.textContent?.trim() || '';
+                
+                // Check if the translated title stored in the attribute matches
+                const storedTranslatedTitle = labelElement.getAttribute('ynt-teaser-translated') || '';
+                
+                // If YouTube changed it to a completely different video (new teaser), stop observing
+                const currentInfoCardData = infoCardDataManager.findByTranslatedTitle(currentText);
+                if (currentInfoCardData && normalizeText(currentInfoCardData.translatedTitle) !== normalizeText(expectedTranslatedTitle)) {
+                    titlesLog('New teaser detected, cleaning up old observer');
+                    cleanupTeaserLabelObserver(labelElement);
+                    return;
+                }
+                
+                // If YouTube changed it back to the translated title, reapply our original title
+                if (normalizeText(currentText) !== normalizeText(originalTitle) && 
+                    normalizeText(currentText) === normalizeText(expectedTranslatedTitle)) {
+                    titlesLog('YouTube changed teaser back to translated, reverting to original');
+                    labelElement.textContent = originalTitle;
+                }
+            }
+        });
+    });
+
+    observer.observe(labelElement, {
+        childList: true,
+        characterData: true,
+        subtree: true
+    });
+
+    teaserLabelObservers.set(labelElement, observer);
+}
+
+/**
+ * Cleans up the observer for a specific teaser label.
+ */
+function cleanupTeaserLabelObserver(labelElement: HTMLElement): void {
+    const observer = teaserLabelObservers.get(labelElement);
+    if (observer) {
+        observer.disconnect();
+        teaserLabelObservers.delete(labelElement);
+    }
+}
+
+/**
+ * Cleans up all teaser label observers.
+ */
+function cleanupAllTeaserLabelObservers(): void {
+    teaserLabelObservers.forEach((observer) => {
+        observer.disconnect();
+    });
+    teaserLabelObservers.clear();
+}
+
+/**
+ * Initializes the observer for infocard teasers in the video overlay.
+ */
+export function setupInfoCardTeasersObserver(): void {
+    cleanupInfoCardTeasersObserver();
+
+    const player = document.getElementById('movie_player');
+    if (!player) {
+        return;
+    }
+
+    teaserObserver = new MutationObserver((mutations) => {
+        let shouldUpdate = false;
+
+        mutations.forEach((mutation) => {
+            // Check for added nodes (teaser appearing)
+            mutation.addedNodes.forEach((node) => {
+                if (node.nodeType === Node.ELEMENT_NODE) {
+                    const element = node as Element;
+                    
+                    // Check if a teaser was added
+                    if (element.classList?.contains('ytp-cards-teaser') ||
+                        element.querySelector('.ytp-cards-teaser')) {
+                        shouldUpdate = true;
+                    }
+                }
+            });
+
+            // Check for attribute changes (display style changing)
+            if (mutation.type === 'attributes' && mutation.attributeName === 'style') {
+                const target = mutation.target as HTMLElement;
+                if (target.classList?.contains('ytp-cards-teaser')) {
+                    // Check if teaser became visible
+                    if (isTeaserVisible(target)) {
+                        shouldUpdate = true;
+                    }
+                }
+            }
+
+            // Check for childList changes inside teaser (label appearing/changing)
+            if (mutation.type === 'childList') {
+                const target = mutation.target as Element;
+                if (target.classList?.contains('ytp-cards-teaser-text') ||
+                    target.closest('.ytp-cards-teaser')) {
+                    shouldUpdate = true;
+                }
+            }
+        });
+
+        if (shouldUpdate) {
+            // Clear existing debounce timer
+            if (teaserDebounceTimer !== null) {
+                clearTimeout(teaserDebounceTimer);
+            }
+
+            // Set new debounce timer
+            teaserDebounceTimer = window.setTimeout(() => {
+                processTeaserIfVisible();
+                teaserDebounceTimer = null;
+            }, TEASER_DEBOUNCE_MS);
+        }
+    });
+
+    teaserObserver.observe(player, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['style']
+    });
+
+    // Also try to process immediately in case teaser is already visible
+    processTeaserIfVisible();
+
+    titlesLog('InfoCard teasers observer initialized');
+}
+
+/**
+ * Cleans up all teaser observers and timers.
+ */
+export function cleanupInfoCardTeasersObserver(): void {
+    if (teaserObserver) {
+        teaserObserver.disconnect();
+        teaserObserver = null;
+    }
+
+    // Clean up all individual teaser label observers
+    cleanupAllTeaserLabelObservers();
+
+    if (teaserDebounceTimer !== null) {
+        clearTimeout(teaserDebounceTimer);
+        teaserDebounceTimer = null;
+    }
+
+    //titlesLog('InfoCard teasers observer cleaned up');
+}


### PR DESCRIPTION
### Feat 

- **InfoCards Support**: Original titles are now restored for video annotations (infocards) in video descriptions and their corresponding overlay teasers
  - Dedicated modular architecture with `infoCards.ts` and `infoCardsTeasers.ts`
  - Smart matching system using Map to link translated and original titles
  - Overlay teasers automatically display original titles when hovering over infocards
  - Individual observers for each teaser to prevent YouTube from reverting changes
  - Automatic detection and cleanup when switching between different teasers
  - Observer for infocard container to detect dynamically loaded cards