### PR TITLE
fix: disable extension on YouTube Music to prevent lag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added "Dev Log" toggle in extra settings (popup and settings page): enables/disables console logs for debugging. Disabled by default.
 
+### Fixed
+- Extension causing lag on YouTube Music (music.youtube.com); extension is now disabled for that domain
+
 ## [2.21.1] - 2026-03-05
 
 ### Performances

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -55,9 +55,19 @@ function isEmbedVideo(): boolean {
     return window.location.pathname.startsWith('/embed/');
 }
 
+function isYouTubeMusic(): boolean {
+    return window.location.hostname === 'music.youtube.com' || 
+           window.location.hostname.startsWith('music.youtube.com');
+}
 
 // Initialize features based on settings
 async function initializeFeatures() {
+
+    if (isYouTubeMusic()) {
+        coreLog('YouTube Music detected; extension disabled for this domain.');
+        return;
+    }
+    
     await fetchSettings();
     
     setupUrlObserver();


### PR DESCRIPTION
Disables the extension on music.youtube.com to prevent performance issues.

The extension was running unnecessarily on YouTube Music causing lag. 
Firefox was flagging the extension as slowing down the page, and disabling 
it for this domain resolved the issue. The exact cause is unclear but likely 
related to the observers and listeners being set up for a page structure 
that doesn't exist on YouTube Music.

Tested on Firefox only.
(large diff is due to line ending differences)

Closes #16