### PR TITLE
fix: keep chapter replacement active after matching initial title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Ensure original chapter titles are restored even when the currently displayed chapter happens to match the original title during initialization.
+
 ## [2.24.2] - 2026-06-17
 
 ### Fixed

--- a/src/content/chapters/chaptersIndex.ts
+++ b/src/content/chapters/chaptersIndex.ts
@@ -365,15 +365,16 @@ export function checkAndInitializeChapters(videoId: string, description: string)
         
         //chaptersLog(`Found ${descriptionChapters.length} chapters in description`);
         
-        // Check if displayed chapters are translated
+        // Initialize whenever original chapters are available. The displayed
+        // chapter used for detection can match by coincidence (for example,
+        // "start" at 0:00) while the rest of the chapters are translated.
         const chaptersTranslated = areChaptersTranslated(descriptionChapters);
-        
-        if (chaptersTranslated) {
-            chaptersLog('Chapters are translated, initializing replacement system');
-            initializeChaptersReplacement(description);
-        } else {
-            chaptersLog('Chapters are already original, skipping replacement system');
-        }
+        chaptersLog(
+            chaptersTranslated
+                ? 'Chapters are translated, initializing replacement system'
+                : 'Original chapters found, initializing replacement system'
+        );
+        initializeChaptersReplacement(description);
     }, 500); // 500ms delay to ensure chapters are rendered
 }
 

--- a/src/content/description/MainDescription.ts
+++ b/src/content/description/MainDescription.ts
@@ -104,7 +104,7 @@ function isDescriptionOriginal(cached: string, current: string): boolean {
 }
 
 
-export async function refreshDescription(id: string): Promise<void> {
+export async function refreshDescription(id: string): Promise<string | null> {
     const isMobile = isMobileSite();
     const descriptionSelector = isMobile 
         ? 'ytm-expandable-video-description-body-renderer' 
@@ -118,7 +118,7 @@ export async function refreshDescription(id: string): Promise<void> {
         const currentVideoId = extractVideoIdFromUrl(window.location.href);
         if (currentVideoId !== id) {
             descriptionLog(`Aborting refreshDescription: video changed from ${id} to ${currentVideoId}`);
-            return;
+            return null;
         }
         
         // First check if we already have the description in cache
@@ -132,7 +132,7 @@ export async function refreshDescription(id: string): Promise<void> {
             const stillCurrentVideoId = extractVideoIdFromUrl(window.location.href);
             if (stillCurrentVideoId !== id) {
                 descriptionLog(`Aborting refreshDescription after fetch: video changed from ${id} to ${stillCurrentVideoId}`);
-                return;
+                return null;
             }
             //descriptionLog('Description element found, injecting script');
         } else {
@@ -145,11 +145,14 @@ export async function refreshDescription(id: string): Promise<void> {
                 // Always update the element, whether it's in cache or not
                 updateDescriptionElement(descriptionElement as HTMLElement, description, id);
                 descriptionLog('Description updated to original');
+                return description;
             }
         }
     } catch (error) {
         descriptionLog(`${error}`);
     }
+
+    return null;
 }
 
 
@@ -437,7 +440,7 @@ export async function processDescriptionForVideoId(id: string): Promise<string |
                 
                 if (!isOriginal) {
                     // Only refresh if not original
-                    return refreshDescription(id).then(() => {
+                    return refreshDescription(id).then((refreshedDescription) => {
                         // Final check before setting up observers
                         const finalVideoId = extractVideoIdFromUrl(window.location.href);
                         if (finalVideoId !== id) {
@@ -448,8 +451,7 @@ export async function processDescriptionForVideoId(id: string): Promise<string |
                         descriptionExpandObserver(id);
                         setupDescriptionContentObserver(id);
                         
-                        // Return the description from cache (was just set because not original)
-                        return descriptionCache.getDescription(id) ?? null;
+                        return refreshedDescription ?? description;
                     });
                 } else {
                     cleanupDescriptionObservers();
@@ -467,7 +469,7 @@ export async function processDescriptionForVideoId(id: string): Promise<string |
                 return null;
             }
             
-            return refreshDescription(id).then(() => {
+            return refreshDescription(id).then((description) => {
                 // Final check before setting up observers
                 const finalVideoId = extractVideoIdFromUrl(window.location.href);
                 if (finalVideoId !== id) {
@@ -478,8 +480,7 @@ export async function processDescriptionForVideoId(id: string): Promise<string |
                 descriptionExpandObserver(id);
                 setupDescriptionContentObserver(id);
                 
-                // Return the description from cache (was just set)
-                return descriptionCache.getDescription(id) ?? null;
+                return description ?? descriptionCache.getDescription(id) ?? null;
             });
         });
     }


### PR DESCRIPTION
## Summary
- initialize chapter replacement whenever original chapters are parsed, even if the currently displayed chapter happens to match
- return the freshly fetched original description through the description processing flow instead of depending on async cache timing
- add a changelog entry

## Related issues
- Closes #133
- Related / duplicate reports: #183, #115, #91, #40
- Related conflict surface: #166

## Verification
- npm run build:chromium
- Loaded the unpacked extension in Chrome through chrome://extensions
- Verified https://www.youtube.com/watch?v=ikkHqYFsPrg with YouTube UI language English:
  - player chapter label changed to original `початок`
  - visible chapters panel rows are original Ukrainian titles
  - hover tooltip around 5:53 shows `від артилерійської до дронової війни`
